### PR TITLE
Version 1.0.27

### DIFF
--- a/globalConfig.json
+++ b/globalConfig.json
@@ -127,7 +127,7 @@
     "meta": {
         "name": "TA-risk-superhandler",
         "restRoot": "ta_risk_superhandler",
-        "version": "1.0.26",
+        "version": "1.0.27",
         "displayName": "Risk superhandler framework for Enterprise Security",
         "schemaVersion": "0.0.3",
         "_uccVersion": "5.39.1"

--- a/package/default/transforms.conf
+++ b/package/default/transforms.conf
@@ -4,4 +4,4 @@
 [risk_superhandler_dedup]
 external_type = kvstore
 collection = kv_risk_superhandler_dedup
-fields_list = _key, mtime, risk_uc_ref, risk_object_type, risk_object
+fields_list = _key, mtime, cim_entity_zone, risk_uc_ref, risk_object_type, risk_object

--- a/package/lib/libs_risksuperhandler.py
+++ b/package/lib/libs_risksuperhandler.py
@@ -70,8 +70,23 @@ def handler_dedup_risk(
     risk_object_type = risk_record["risk_object_type"]
     risk_object = risk_record["risk_object"]
 
+    # take into account the cim_entity_zone, if any
+    risk_cim_entity_zone = risk_record.get("cim_entity_zone", None)
+
     # define unique factor and its md5
-    mv_record_key_factors = f"{uc_ref}:{risk_object_type}:{risk_object}"
+    if risk_cim_entity_zone:
+        mv_record_key_factors = (
+            f"{uc_ref}:{risk_cim_entity_zone}:{risk_object_type}:{risk_object}"
+        )
+
+    else:
+        mv_record_key_factors = f"{uc_ref}:{risk_object_type}:{risk_object}"
+
+    # for visualization purposes
+    if not risk_cim_entity_zone:
+        risk_cim_entity_zone = "N/A"
+
+    # calculate the md5
     mv_record_key_md5 = hashlib.md5(mv_record_key_factors.encode()).hexdigest()
 
     # check if mv_record_key_factors is in the dedup collection
@@ -114,6 +129,7 @@ def handler_dedup_risk(
                     json.dumps(
                         {
                             "mtime": time.time(),
+                            "cim_entity_zone": risk_cim_entity_zone,
                             "risk_uc_ref": uc_ref,
                             "risk_object_type": risk_object_type,
                             "risk_object": risk_object,
@@ -142,6 +158,7 @@ def handler_dedup_risk(
                     {
                         "_key": mv_record_key_md5,
                         "mtime": time.time(),
+                        "cim_entity_zone": risk_cim_entity_zone,
                         "risk_uc_ref": uc_ref,
                         "risk_object_type": risk_object_type,
                         "risk_object": risk_object,

--- a/package/lib/requirements.txt
+++ b/package/lib/requirements.txt
@@ -1,3 +1,1 @@
 splunktaucclib>=5.0.4
-deprecation>=2.1.0
-splunk-sdk<2.0.0

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.0.26",
+  "version": "1.0.27",
   "appID": "TA-risk-superhandler"
 }


### PR DESCRIPTION
- enhancement - Dedup - Automatically take into account cim_entity_zone if available in the upstream results #18
- change - Upgrade to Splunk Python SDK 2.0.1 #17

SHA-256: 