### PR TITLE
Version 1.0.28

### DIFF
--- a/docs/releasenotes.rst
+++ b/docs/releasenotes.rst
@@ -1,6 +1,11 @@
 Release notes
 -------------
 
+Version 1.0.28
+==============
+
+- Refresh Splunk UCC, Splunk Python SDK and others libs to address Appinspect vetting removal due to outdated dependencies
+
 Version 1.0.27
 ==============
 

--- a/globalConfig.json
+++ b/globalConfig.json
@@ -3,41 +3,7 @@
         "configuration": {
             "tabs": [
                 {
-                    "name": "logging",
-                    "entity": [
-                        {
-                            "type": "singleSelect",
-                            "label": "Log level",
-                            "options": {
-                                "disableSearch": true,
-                                "autoCompleteFields": [
-                                    {
-                                        "value": "DEBUG",
-                                        "label": "DEBUG"
-                                    },
-                                    {
-                                        "value": "INFO",
-                                        "label": "INFO"
-                                    },
-                                    {
-                                        "value": "WARNING",
-                                        "label": "WARNING"
-                                    },
-                                    {
-                                        "value": "ERROR",
-                                        "label": "ERROR"
-                                    },
-                                    {
-                                        "value": "CRITICAL",
-                                        "label": "CRITICAL"
-                                    }
-                                ]
-                            },
-                            "defaultValue": "INFO",
-                            "field": "loglevel"
-                        }
-                    ],
-                    "title": "Logging"
+                    "type": "loggingTab"
                 },
                 {
                     "name": "advanced_configuration",
@@ -127,9 +93,9 @@
     "meta": {
         "name": "TA-risk-superhandler",
         "restRoot": "ta_risk_superhandler",
-        "version": "1.0.27",
+        "version": "1.0.28",
         "displayName": "Risk superhandler framework for Enterprise Security",
-        "schemaVersion": "0.0.3",
-        "_uccVersion": "5.39.1"
+        "schemaVersion": "0.0.7",
+        "_uccVersion": "5.48.2"
     }
 }

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 splunk-add-on-ucc-framework>=5.35.0
 coloredlogs>=15.0.1
 colorama>=0.4.6
+requests>=2.32.3

--- a/version.json
+++ b/version.json
@@ -1,4 +1,4 @@
 {
-  "version": "1.0.27",
+  "version": "1.0.28",
   "appID": "TA-risk-superhandler"
 }


### PR DESCRIPTION
- Refresh Splunk UCC, Splunk Python SDK and others libs to address Appinspect vetting removal due to outdated dependencies